### PR TITLE
feat: improve logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@jsdevtools/rehype-toc": "^3.0.2",
     "@notionhq/client": "^2.2.0",
+    "kleur": "^4.1.5",
     "notion-rehype-k": "^1.1.6",
     "rehype-katex": "^6.0.0",
     "rehype-slug": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@notionhq/client':
         specifier: ^2.2.0
         version: 2.3.0
+      kleur:
+        specifier: ^4.1.5
+        version: 4.1.5
       notion-rehype-k:
         specifier: ^1.1.6
         version: 1.1.6

--- a/src/image.ts
+++ b/src/image.ts
@@ -11,7 +11,32 @@ export interface SaveOptions {
 
 export const VIRTUAL_CONTENT_ROOT = 'src/content/notion';
 
-// example: https://prod-files-secure.s3.us-west-2.amazonaws.com/ed3b245b-dd96-4e0d-a399-9a99a0cf37c0/d16195b7-f998-4b7c-8d2e-38b9c47be295/image.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45FSPPWI6X/20250123/us-west-2/s3/aws4_request&X-Amz-Date=20250123T145339Z&X-Amz-Expires=3600&X-Amz-Signature=c67284d3172499aa2f41faa55710f81ec49f53687c500ad1a794b2c0410d477f&X-Amz-SignedHeaders=host&x-id=GetObject
+/**
+ * Downloads and saves an image from an AWS URL to a local directory.
+ *
+ * @param url The AWS URL of the image to download.
+ * @param dir The directory path where the image will be saved.
+ * @param options Optional configuration for saving the image.
+ * @param options.ignoreCache Whether to ignore cached images and download again. Defaults to false.
+ * @param options.log Optional logging function to record the operation.
+ * @param options.tag Optional tagging function to mark the operation as 'download' or 'cached'.
+ *
+ * @returns The relative path of the saved image from the project's virtual content root.
+ *
+ * @throws {Error} If the provided `url` is invalid.
+ *
+ * @example
+ * For the following AWS URL:
+ * https://prod-files-secure.s3.us-west-2.amazonaws.com/ed3b245b-dd96-4e0d-a399-9a99a0cf37c0/d16195b7-f998-4b7c-8d2e-38b9c47be295/image.png?...
+ *
+ * The function parses the URL into:
+ * - Parent ID: ed3b245b-dd96-4e0d-a399-9a99a0cf37c0
+ * - Object ID: d16195b7-f998-4b7c-8d2e-38b9c47be295
+ * - File Name: image.png
+ *
+ * And saves it to:
+ * ./src/{dir}/ed3b245b-dd96-4e0d-a399-9a99a0cf37c0/d16195b7-f998-4b7c-8d2e-38b9c47be295.png
+ */
 export async function saveImageFromAWS(url: string, dir: string, options: SaveOptions = {}) {
   const { ignoreCache, log, tag } = options;
 
@@ -56,6 +81,9 @@ export async function saveImageFromAWS(url: string, dir: string, options: SaveOp
   return path.relative(relBasePath, filePath);
 }
 
+/**
+ * Transforms a raw image path into a relative path from the 'src' directory.
+ */
 export function transformImagePathForCover(rawPath: string): string {
   // get abs path from relative path to VIRTUAL_CONTENT_ROOT
   const absPath = path.resolve(process.cwd(), VIRTUAL_CONTENT_ROOT, rawPath);

--- a/src/image.ts
+++ b/src/image.ts
@@ -1,5 +1,6 @@
 import fse from 'fs-extra';
 import path from 'node:path';
+import { dim } from 'kleur/colors';
 export interface SaveOptions {
   ignoreCache?: boolean;
   log?: (message: string) => void;
@@ -11,38 +12,45 @@ export const VIRTUAL_CONTENT_ROOT = 'src/content/notion';
 // example: https://prod-files-secure.s3.us-west-2.amazonaws.com/ed3b245b-dd96-4e0d-a399-9a99a0cf37c0/d16195b7-f998-4b7c-8d2e-38b9c47be295/image.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45FSPPWI6X/20250123/us-west-2/s3/aws4_request&X-Amz-Date=20250123T145339Z&X-Amz-Expires=3600&X-Amz-Signature=c67284d3172499aa2f41faa55710f81ec49f53687c500ad1a794b2c0410d477f&X-Amz-SignedHeaders=host&x-id=GetObject
 export async function saveImageFromAWS(url: string, dir: string, options: SaveOptions = {}) {
   const { ignoreCache, log, tag } = options;
-  const enableCache = !ignoreCache;
 
   if (!fse.existsSync(dir)) {
     throw new Error(`Directory ${dir} does not exist`);
   }
 
-  const _url = new URL(url);
-  const [parentId, objId, fileName] = _url.pathname.split('/').filter(Boolean); // 排除掉第一个空字符串
+  // Validate and parse the URL
+  const [parentId, objId, fileName] = new URL(url).pathname.split('/').filter(Boolean); // Remove empty strings
+
   if (!fileName || !parentId || !objId) {
     throw new Error('Invalid URL');
   }
-  const ext = fileName.split('.').at(-1);
 
-  const saveDirPath = path.resolve(dir, parentId); // 存储在page文件夹中
+  // Path to parent directory of the image
+  // ./src/{dir}/{parentId}
+  const saveDirPath = path.resolve(dir, parentId);
   fse.ensureDirSync(saveDirPath);
 
+  const ext = fileName.split('.').at(-1);
+
+  // Path to the image file
+  // ./src/{dir}/{parentId}/{objId}.{ext}
   const filePath = path.resolve(saveDirPath, `${objId}.${ext}`);
 
-  if (!enableCache || !fse.existsSync(filePath)) {
+  if (ignoreCache || !fse.existsSync(filePath)) {
+    // If ignoreCache is true or the file doesn't exist, download it
     const response = await fetch(url);
     const buffer = await response.arrayBuffer();
     fse.writeFile(filePath, new Uint8Array(buffer));
-    log?.(`Saved image ${fileName} to ${filePath}`);
+
+    log?.(`Saved image \`${fileName}\` ${dim(`created \`${filePath}\``)}`);
     tag?.('download');
   } else {
-    log?.(`Skip saving image ${fileName}, since it is cached.`);
+    log?.(`Skipped caching image \`${fileName}\` ${dim(`cached at \`${filePath}\``)}`);
     tag?.('cached');
   }
 
   const relBasePath = path.resolve(process.cwd(), VIRTUAL_CONTENT_ROOT);
 
-  // 返回的是相对项目目录下.astro文件的路径
+  // Relative path of the image from the virtual content root
   return path.relative(relBasePath, filePath);
 }
 

--- a/src/image.ts
+++ b/src/image.ts
@@ -1,6 +1,8 @@
 import fse from 'fs-extra';
 import path from 'node:path';
+
 import { dim } from 'kleur/colors';
+
 export interface SaveOptions {
   ignoreCache?: boolean;
   log?: (message: string) => void;

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -21,6 +21,11 @@ export interface NotionLoaderOptions
    */
   rehypePlugins?: RehypePlugins;
   /**
+   * The name of the collection, only used for logging and debugging purposes.
+   * Useful for multiple loaders to differentiate their logs.
+   */
+  collectionName?: string;
+  /**
    * The path to save the images.
    * Defaults to 'public'.
    */
@@ -74,6 +79,7 @@ export function notionLoader({
   sorts,
   filter,
   archived,
+  collectionName,
   imageSavePath = DEFAULT_IMAGE_SAVE_PATH,
   rehypePlugins = [],
   experimentalCacheImageInData = false,
@@ -101,7 +107,7 @@ export function notionLoader({
   const processor = buildProcessor(resolvedRehypePlugins);
 
   return {
-    name: 'notion-loader',
+    name: collectionName ? `notion-loader/${collectionName}` : 'notion-loader',
     schema: async () =>
       notionPageSchema({
         properties: await propertiesSchemaForDatabase(notionClient, database_id),

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -7,6 +7,8 @@ import { notionPageSchema } from './schemas/page.js';
 import type { ClientOptions, QueryDatabaseParameters } from './types.js';
 import * as path from 'node:path';
 import { VIRTUAL_CONTENT_ROOT } from './image.js';
+import { dim } from 'kleur/colors';
+import * as transformedPropertySchema from './schemas/transformed-properties.js';
 
 export interface NotionLoaderOptions
   extends Pick<ClientOptions, 'auth' | 'timeoutMs' | 'baseUrl' | 'notionVersion' | 'fetch' | 'agent'>,
@@ -103,11 +105,12 @@ export function notionLoader({
         properties: await propertiesSchemaForDatabase(notionClient, database_id),
       }),
     async load(ctx) {
-      const { store, logger, parseData } = ctx;
-      logger.info('Loading notion pages');
+      const { store, logger: log_db, parseData } = ctx;
 
       const existingPageIds = new Set<string>(store.keys());
       const renderPromises: Promise<void>[] = [];
+
+      log_db.info(`Loading database ${dim(`found ${existingPageIds.size} pages in store`)}`);
 
       const pages = iteratePaginatedAPI(notionClient.databases.query, {
         database_id,
@@ -116,19 +119,33 @@ export function notionLoader({
         filter,
         archived,
       });
+      let pageCount = 0;
+
       for await (const page of pages) {
         if (!isFullPage(page)) {
           continue;
         }
 
-        existingPageIds.delete(page.id);
+        pageCount++;
+
+        const log_pg = log_db.fork(`${log_db.label}/${page.id.slice(0, 6)}`);
+
+        // Create metadata for logging
+        const titleProp = Object.entries(page.properties).find(([_, property]) => property.type === 'title');
+        const pageTitle = transformedPropertySchema.title.safeParse(titleProp ? titleProp[1] : {});
+        const pageMetadata = [
+          `${pageTitle.success ? '"' + pageTitle.data + '"' : 'Untitled'}`,
+          `(last edited ${page.last_edited_time.slice(0, 10)})`,
+        ].join(' ');
+
+        const isCached = existingPageIds.delete(page.id);
         const existingPage = store.get(page.id);
 
         // If the page has been updated, re-render it
         if (existingPage?.digest !== page.last_edited_time) {
           const realSavePath = path.resolve(process.cwd(), 'src', imageSavePath);
 
-          const renderer = new NotionPageRenderer(notionClient, page, realSavePath, logger);
+          const renderer = new NotionPageRenderer(notionClient, page, realSavePath, log_pg);
 
           const data = await parseData(
             await renderer.getPageData(experimentalCacheImageInData, experimentalRootSourceAlias)
@@ -146,16 +163,31 @@ export function notionLoader({
           });
 
           renderPromises.push(renderPromise);
+
+          log_pg.info(`${isCached ? 'Updated' : 'Created'} page ${dim(pageMetadata)}`);
+        } else {
+          log_pg.debug(`Skipped page ${dim(pageMetadata)}`);
         }
       }
 
       // Remove any pages that have been deleted
       for (const deletedPageId of existingPageIds) {
+        const log_pg = log_db.fork(`${log_db.label}/${deletedPageId.slice(0, 6)}`);
+
         store.delete(deletedPageId);
+        log_pg.info(`Deleted page`);
+      }
+
+      log_db.info(`Loaded database ${dim(`fetched ${pageCount} pages from API`)}`);
+
+      if (renderPromises.length === 0) {
+        return;
       }
 
       // Wait for rendering to complete
+      log_db.info(`Rendering ${renderPromises.length} updated pages`);
       await Promise.all(renderPromises);
+      log_db.info(`Rendered ${renderPromises.length} pages`);
     },
   };
 }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,14 +1,16 @@
-import { Client, isFullPage, iteratePaginatedAPI } from '@notionhq/client';
 import type { RehypePlugins } from 'astro';
 import type { Loader } from 'astro/loaders';
+
+import { Client, isFullPage, iteratePaginatedAPI } from '@notionhq/client';
+import { dim } from 'kleur/colors';
+import * as path from 'node:path';
+
 import { propertiesSchemaForDatabase } from './database-properties.js';
+import { VIRTUAL_CONTENT_ROOT } from './image.js';
 import { buildProcessor, NotionPageRenderer, type RehypePlugin } from './render.js';
 import { notionPageSchema } from './schemas/page.js';
-import type { ClientOptions, QueryDatabaseParameters } from './types.js';
-import * as path from 'node:path';
-import { VIRTUAL_CONTENT_ROOT } from './image.js';
-import { dim } from 'kleur/colors';
 import * as transformedPropertySchema from './schemas/transformed-properties.js';
+import type { ClientOptions, QueryDatabaseParameters } from './types.js';
 
 export interface NotionLoaderOptions
   extends Pick<ClientOptions, 'auth' | 'timeoutMs' | 'baseUrl' | 'notionVersion' | 'fetch' | 'agent'>,

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,24 +1,24 @@
-import type { HtmlElementNode, ListNode, TextNode } from '@jsdevtools/rehype-toc';
-import { toc as rehypeToc } from '@jsdevtools/rehype-toc';
-import { type Client, iteratePaginatedAPI, isFullBlock } from '@notionhq/client';
 import type { AstroIntegrationLogger, MarkdownHeading } from 'astro';
 import type { ParseDataOptions } from 'astro/loaders';
 
-import type { FileObject, NotionPageData, PageObjectResponse } from './types.js';
-import * as transformedPropertySchema from './schemas/transformed-properties.js';
-import { fileToUrl } from './format.js';
-import { type VFile } from 'vfile';
-import { dim } from 'kleur/colors';
-
 // #region Processor
+import * as fse from 'fs-extra';
 import notionRehype from 'notion-rehype-k';
 import rehypeKatex from 'rehype-katex';
 import rehypeSlug from 'rehype-slug';
 import rehypeStringify from 'rehype-stringify';
 import { unified, type Plugin } from 'unified';
+import { type VFile } from 'vfile';
+
+import type { HtmlElementNode, ListNode, TextNode } from '@jsdevtools/rehype-toc';
+import { toc as rehypeToc } from '@jsdevtools/rehype-toc';
+import { isFullBlock, iteratePaginatedAPI, type Client } from '@notionhq/client';
+import { dim } from 'kleur/colors';
+
+import { fileToUrl } from './format.js';
 import { saveImageFromAWS, transformImagePathForCover } from './image.js';
-import * as fse from 'fs-extra';
 import { rehypeImages } from './rehype/rehype-images.js';
+import type { FileObject, NotionPageData, PageObjectResponse } from './types.js';
 
 const baseProcessor = unified()
   .use(notionRehype, {}) // Parse Notion blocks to rehype AST


### PR DESCRIPTION
Improves visual style, language and information in the build logs.

## Changes

- Added `kleur` package to control log text color (`kleur` is used in Astro internally)
- Updated language to match style used in default Astro build steps
- Added `collectionName` option to loader options (useful if you are using multiple loaders to differentiate their logs)
- Updated docs on `image.ts`

## Example

### `content.config.ts`

```ts
import { defineCollection } from "astro:content";
import { notionLoader } from "notion-astro-loader";

const blog = defineCollection({
  loader: notionLoader({
    collectionName: "blog",
    database_id: "...",
    auth: import.meta.env.NOTION_TOKEN,
  }),
});

const things = defineCollection({
  loader: notionLoader({
    collectionName: "things",
    database_id: "...",
    auth: import.meta.env.NOTION_TOKEN,
  }),
});

const gallery = defineCollection({
  loader: notionLoader({
    collectionName: "gallery",
    database_id: "...",
    auth: import.meta.env.NOTION_TOKEN,
  }),
});

export const collections = { blog, things, gallery };

```

### Log output

<img width="1046" alt="image" src="https://github.com/user-attachments/assets/92c9cb0b-07d8-472a-9263-4c58b91e6f21" />